### PR TITLE
Enable mujoco-python on ppc64le

### DIFF
--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -16,6 +16,20 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+numpy:
+- '1.21'
+- '1.20'
+- '1.20'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+pybind11_abi:
+- '4'
+python:
+- 3.10.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - linux-ppc64le
 tinyxml2:
@@ -23,3 +37,5 @@ tinyxml2:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - python
+  - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,7 @@ source:
 
 
 build:
-  number: 0
-  skip: true  # [py<37]
+  number: 1
 
 outputs:
   - name: {{ namecxx }}
@@ -67,8 +66,6 @@ outputs:
 
 
   - name: {{ namepython }}
-    build:
-      skip: true  # [ppc64le]
     script: build_py.sh  # [unix]
     script: bld_py.bat  # [win]
     requirements:


### PR DESCRIPTION
Fix https://github.com/conda-forge/mujoco-feedstock/issues/6 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
