### PR TITLE
Migrate to libabseil and rename mujoco-cxx to libmujoco

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,3 @@
-abseil_cpp:
-- '20220623.0'
 c_compiler:
 - gcc
 c_compiler_version:
@@ -16,6 +14,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libabseil:
+- '20220623.0'
 numpy:
 - '1.21'
 - '1.23'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,5 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
-abseil_cpp:
-- '20220623.0'
 c_compiler:
 - gcc
 c_compiler_version:
@@ -20,6 +18,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libabseil:
+- '20220623.0'
 numpy:
 - '1.21'
 - '1.23'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,5 +1,3 @@
-abseil_cpp:
-- '20220623.0'
 c_compiler:
 - gcc
 c_compiler_version:
@@ -16,6 +14,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libabseil:
+- '20220623.0'
 numpy:
 - '1.21'
 - '1.23'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.14'
 MACOSX_SDK_VERSION:
 - '10.15'
-abseil_cpp:
-- '20220623.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -16,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '14'
+libabseil:
+- '20220623.0'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-abseil_cpp:
-- '20220623.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -14,6 +12,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '14'
+libabseil:
+- '20220623.0'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,3 @@
-abseil_cpp:
-- '20220623.0'
 c_compiler:
 - vs2019
 channel_sources:
@@ -8,6 +6,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libabseil:
+- '20220623.0'
 numpy:
 - '1.21'
 - '1.23'

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libmujoco-green.svg)](https://anaconda.org/conda-forge/libmujoco) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libmujoco.svg)](https://anaconda.org/conda-forge/libmujoco) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libmujoco.svg)](https://anaconda.org/conda-forge/libmujoco) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libmujoco.svg)](https://anaconda.org/conda-forge/libmujoco) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-mujoco-green.svg)](https://anaconda.org/conda-forge/mujoco) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mujoco.svg)](https://anaconda.org/conda-forge/mujoco) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mujoco.svg)](https://anaconda.org/conda-forge/mujoco) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mujoco.svg)](https://anaconda.org/conda-forge/mujoco) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-mujoco--cxx-green.svg)](https://anaconda.org/conda-forge/mujoco-cxx) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mujoco-cxx.svg)](https://anaconda.org/conda-forge/mujoco-cxx) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mujoco-cxx.svg)](https://anaconda.org/conda-forge/mujoco-cxx) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mujoco-cxx.svg)](https://anaconda.org/conda-forge/mujoco-cxx) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-mujoco--python-green.svg)](https://anaconda.org/conda-forge/mujoco-python) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mujoco-python.svg)](https://anaconda.org/conda-forge/mujoco-python) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mujoco-python.svg)](https://anaconda.org/conda-forge/mujoco-python) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mujoco-python.svg)](https://anaconda.org/conda-forge/mujoco-python) |
 
 Installing mujoco
@@ -95,41 +95,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `mujoco, mujoco-cxx, mujoco-python` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `libmujoco, mujoco, mujoco-python` can be installed with `conda`:
 
 ```
-conda install mujoco mujoco-cxx mujoco-python
-```
-
-or with `mamba`:
-
-```
-mamba install mujoco mujoco-cxx mujoco-python
-```
-
-It is possible to list all of the versions of `mujoco` available on your platform with `conda`:
-
-```
-conda search mujoco --channel conda-forge
+conda install libmujoco mujoco mujoco-python
 ```
 
 or with `mamba`:
 
 ```
-mamba search mujoco --channel conda-forge
+mamba install libmujoco mujoco mujoco-python
+```
+
+It is possible to list all of the versions of `libmujoco` available on your platform with `conda`:
+
+```
+conda search libmujoco --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search libmujoco --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search mujoco --channel conda-forge
+mamba repoquery search libmujoco --channel conda-forge
 
-# List packages depending on `mujoco`:
-mamba repoquery whoneeds mujoco --channel conda-forge
+# List packages depending on `libmujoco`:
+mamba repoquery whoneeds libmujoco --channel conda-forge
 
-# List dependencies of `mujoco`:
-mamba repoquery depends mujoco --channel conda-forge
+# List dependencies of `libmujoco`:
+mamba repoquery depends libmujoco --channel conda-forge
 ```
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,9 @@ outputs:
         - lodepng
       run:
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
+      run_constrained:
+        # Older version of this package were named mujoco-cxx, we want to avoid that they are installed
+        - mujoco-cxx <0
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mujoco" %}
-{% set namecxx = "mujoco-cxx" %}
+{% set namecxx = "libmujoco" %}
 {% set namepython = "mujoco-python" %}
 {% set version = "2.3.1.post1" %}
 
@@ -27,7 +27,7 @@ source:
     - simulate_unvendor_lodepng.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ namecxx }}
@@ -36,10 +36,10 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage(namecxx, max_pin='x.x.x') }}
-      # abseil-cpp is used only for tests, we can 
+      # libabseil is used only for tests, we can 
       # safely ignore its run_exports
       ignore_run_exports:
-        - abseil-cpp
+        - libabseil
     requirements:
       build:
         - cmake
@@ -53,7 +53,7 @@ outputs:
         - qhull
         - tinyxml2
         - libccd-double
-        - abseil-cpp
+        - libabseil
         - lodepng
       run:
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
@@ -98,7 +98,7 @@ outputs:
       host:
         - {{ pin_subpackage(namecxx, exact=True) }}
         - eigen
-        - abseil-cpp
+        - libabseil
         - python
         - pip
         - setuptools


### PR DESCRIPTION
Fix https://github.com/conda-forge/mujoco-feedstock/issues/16 .

@h-vetinari I did not find any occurence of `mujoco-cxx` on GitHub, so I think the rename is quite safe. Anyhow, do you have any suggestions on how to advertise/document such a name change? I would list the currently updated outputs in the README, but the summary is expected to be just one sentence (at least from https://conda-forge.org/docs/orga/guidelines.html#transferring-to-conda-forge).

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
