### PR TITLE
Add missing run dependency of mujoco-samples and mujoco-simulate on libmujoco

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
 build:
   # See https://github.com/conda-forge/mujoco-feedstock/issues/22
   skip: true  # [(aarch64 or ppc64le or osx) and python_impl == 'pypy']
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ namecxx }}
@@ -114,6 +114,8 @@ outputs:
         - libmujoco
         - glfw
       run:
+        # Somehow the libmujoco run_exports is ignored here, let's add explicitly the run dependency
+        - {{ pin_subpackage(namecxx, max_pin='x.x.x') }}
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
     test:
@@ -154,6 +156,8 @@ outputs:
         - libmujoco
         - glfw
       run:
+        # Somehow the libmujoco run_exports is ignored here, let's add explicitly the run dependency
+        - {{ pin_subpackage(namecxx, max_pin='x.x.x') }}
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
 
     test:


### PR DESCRIPTION
Partial fix for https://github.com/conda-forge/mujoco-feedstock/issues/46 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
