### PR TITLE
Upgrade to MuJoCo 3.3.1, add debugging, fix Windows

### DIFF
--- a/recipe/add-msys-windows-platform.patch
+++ b/recipe/add-msys-windows-platform.patch
@@ -1,0 +1,34 @@
+From 66f34dd3ef1d0ea26213cf44dad97dbaabcd15ef Mon Sep 17 00:00:00 2001
+From: Jacob Oursland <jacob.oursland@gmail.com>
+Date: Fri, 18 Apr 2025 01:07:09 -0700
+Subject: [PATCH] Add MSYS as a Windows platform.
+
+---
+ python/make_sdist.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/python/make_sdist.sh b/python/make_sdist.sh
+index da4c3260..0eec1a9b 100755
+--- a/python/make_sdist.sh
++++ b/python/make_sdist.sh
+@@ -21,7 +21,7 @@ fi
+ # Figure out the path to this script (https://stackoverflow.com/a/246128).
+ package_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ 
+-if [[ "$(uname)" == CYGWIN* || "$(uname)" == MINGW* ]]; then
++if [[ "$(uname)" == CYGWIN* || "$(uname)" == MINGW* || "$(uname)" == MSYS* ]]; then
+   package_dir="$(cygpath -m ${package_dir})"
+   readonly tmp_dir="$(TMPDIR="${LOCALAPPDATA//\\/$'/'}/Temp" mktemp -d)"
+ else
+@@ -35,7 +35,7 @@ cp -r "${package_dir}"/* .
+ 
+ # Generate header files.
+ old_pythonpath="${PYTHONPATH}"
+-if [[ "$(uname)" == CYGWIN* || "$(uname)" == MINGW* ]]; then
++if [[ "$(uname)" == CYGWIN* || "$(uname)" == MINGW* || "$(uname)" == MSYS* ]]; then
+   export PYTHONPATH="${old_pythonpath};${package_dir}/mujoco/python/.."
+ else
+   export PYTHONPATH="${old_pythonpath}:${package_dir}/mujoco/python/.."
+-- 
+2.49.0
+

--- a/recipe/bld_py.bat
+++ b/recipe/bld_py.bat
@@ -10,7 +10,7 @@ set CMAKE_GENERATOR_TOOLSET=
 cd %SRC_DIR%\python
 # Workaround for missing pxr import https://github.com/conda-forge/mujoco-feedstock/pull/62
 del /F .\mujoco\usd\exporter_test.py
-bash make_sdist.sh
+bash -xe make_sdist.sh
 if errorlevel 1 exit 1
 
 :: Without this, the setup.py fails on Windows as it tries to access

--- a/recipe/build_py.sh
+++ b/recipe/build_py.sh
@@ -8,7 +8,7 @@ fi
 cd $SRC_DIR/python
 # Workaround for missing pxr import https://github.com/conda-forge/mujoco-feedstock/pull/62
 rm -rf ./mujoco/usd/exporter_test.py
-bash make_sdist.sh
+bash -xe make_sdist.sh
 cd dist
 export MUJOCO_PATH=$PREFIX
 export MUJOCO_PLUGIN_PATH=$PREFIX/bin/mujoco_plugin

--- a/recipe/cmake-required-link-options.patch
+++ b/recipe/cmake-required-link-options.patch
@@ -1,0 +1,142 @@
+From 4b40cb7ba3c20c57a767eeb2cece0e54dbf84a21 Mon Sep 17 00:00:00 2001
+From: Jacob Oursland <jacob.oursland@gmail.com>
+Date: Thu, 17 Apr 2025 13:32:58 -0700
+Subject: [PATCH] CMake: use CMAKE_REQUIRED_LINK_OPTIONS instead of
+ CMAKE_REQUIRED_FLAGS for linker flags.
+
+See https://github.com/google-deepmind/mujoco_mpc/pull/253
+---
+ cmake/MujocoLinkOptions.cmake          | 10 +++++-----
+ sample/cmake/MujocoLinkOptions.cmake   | 10 +++++-----
+ simulate/cmake/MujocoLinkOptions.cmake | 10 +++++-----
+ 3 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/cmake/MujocoLinkOptions.cmake b/cmake/MujocoLinkOptions.cmake
+index 242767f9..1762ba79 100644
+--- a/cmake/MujocoLinkOptions.cmake
++++ b/cmake/MujocoLinkOptions.cmake
+@@ -23,7 +23,7 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
+     set(EXTRA_LINK_OPTIONS)
+ 
+     if(WIN32)
+-      set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld-link")
++      set(CMAKE_REQUIRED_LINK_OPTIONS "-fuse-ld=lld-link")
+       check_c_source_compiles("int main() {}" SUPPORTS_LLD)
+       if(SUPPORTS_LLD)
+         set(EXTRA_LINK_OPTIONS
+@@ -34,24 +34,24 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
+         )
+       endif()
+     else()
+-      set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
++      set(CMAKE_REQUIRED_LINK_OPTIONS "-fuse-ld=lld")
+       check_c_source_compiles("int main() {}" SUPPORTS_LLD)
+       if(SUPPORTS_LLD)
+         set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=lld)
+       else()
+-        set(CMAKE_REQUIRED_FLAGS "-fuse-ld=gold")
++        set(CMAKE_REQUIRED_LINK_OPTIONS "-fuse-ld=gold")
+         check_c_source_compiles("int main() {}" SUPPORTS_GOLD)
+         if(SUPPORTS_GOLD)
+           set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=gold)
+         endif()
+       endif()
+ 
+-      set(CMAKE_REQUIRED_FLAGS ${EXTRA_LINK_OPTIONS} "-Wl,--gc-sections")
++      set(CMAKE_REQUIRED_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} "-Wl,--gc-sections")
+       check_c_source_compiles("int main() {}" SUPPORTS_GC_SECTIONS)
+       if(SUPPORTS_GC_SECTIONS)
+         set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,--gc-sections)
+       else()
+-        set(CMAKE_REQUIRED_FLAGS ${EXTRA_LINK_OPTIONS} "-Wl,-dead_strip")
++        set(CMAKE_REQUIRED_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} "-Wl,-dead_strip")
+         check_c_source_compiles("int main() {}" SUPPORTS_DEAD_STRIP)
+         if(SUPPORTS_DEAD_STRIP)
+           set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,-dead_strip)
+diff --git a/sample/cmake/MujocoLinkOptions.cmake b/sample/cmake/MujocoLinkOptions.cmake
+index 242767f9..1762ba79 100644
+--- a/sample/cmake/MujocoLinkOptions.cmake
++++ b/sample/cmake/MujocoLinkOptions.cmake
+@@ -23,7 +23,7 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
+     set(EXTRA_LINK_OPTIONS)
+ 
+     if(WIN32)
+-      set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld-link")
++      set(CMAKE_REQUIRED_LINK_OPTIONS "-fuse-ld=lld-link")
+       check_c_source_compiles("int main() {}" SUPPORTS_LLD)
+       if(SUPPORTS_LLD)
+         set(EXTRA_LINK_OPTIONS
+@@ -34,24 +34,24 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
+         )
+       endif()
+     else()
+-      set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
++      set(CMAKE_REQUIRED_LINK_OPTIONS "-fuse-ld=lld")
+       check_c_source_compiles("int main() {}" SUPPORTS_LLD)
+       if(SUPPORTS_LLD)
+         set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=lld)
+       else()
+-        set(CMAKE_REQUIRED_FLAGS "-fuse-ld=gold")
++        set(CMAKE_REQUIRED_LINK_OPTIONS "-fuse-ld=gold")
+         check_c_source_compiles("int main() {}" SUPPORTS_GOLD)
+         if(SUPPORTS_GOLD)
+           set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=gold)
+         endif()
+       endif()
+ 
+-      set(CMAKE_REQUIRED_FLAGS ${EXTRA_LINK_OPTIONS} "-Wl,--gc-sections")
++      set(CMAKE_REQUIRED_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} "-Wl,--gc-sections")
+       check_c_source_compiles("int main() {}" SUPPORTS_GC_SECTIONS)
+       if(SUPPORTS_GC_SECTIONS)
+         set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,--gc-sections)
+       else()
+-        set(CMAKE_REQUIRED_FLAGS ${EXTRA_LINK_OPTIONS} "-Wl,-dead_strip")
++        set(CMAKE_REQUIRED_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} "-Wl,-dead_strip")
+         check_c_source_compiles("int main() {}" SUPPORTS_DEAD_STRIP)
+         if(SUPPORTS_DEAD_STRIP)
+           set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,-dead_strip)
+diff --git a/simulate/cmake/MujocoLinkOptions.cmake b/simulate/cmake/MujocoLinkOptions.cmake
+index 242767f9..1762ba79 100644
+--- a/simulate/cmake/MujocoLinkOptions.cmake
++++ b/simulate/cmake/MujocoLinkOptions.cmake
+@@ -23,7 +23,7 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
+     set(EXTRA_LINK_OPTIONS)
+ 
+     if(WIN32)
+-      set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld-link")
++      set(CMAKE_REQUIRED_LINK_OPTIONS "-fuse-ld=lld-link")
+       check_c_source_compiles("int main() {}" SUPPORTS_LLD)
+       if(SUPPORTS_LLD)
+         set(EXTRA_LINK_OPTIONS
+@@ -34,24 +34,24 @@ function(get_mujoco_extra_link_options OUTPUT_VAR)
+         )
+       endif()
+     else()
+-      set(CMAKE_REQUIRED_FLAGS "-fuse-ld=lld")
++      set(CMAKE_REQUIRED_LINK_OPTIONS "-fuse-ld=lld")
+       check_c_source_compiles("int main() {}" SUPPORTS_LLD)
+       if(SUPPORTS_LLD)
+         set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=lld)
+       else()
+-        set(CMAKE_REQUIRED_FLAGS "-fuse-ld=gold")
++        set(CMAKE_REQUIRED_LINK_OPTIONS "-fuse-ld=gold")
+         check_c_source_compiles("int main() {}" SUPPORTS_GOLD)
+         if(SUPPORTS_GOLD)
+           set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -fuse-ld=gold)
+         endif()
+       endif()
+ 
+-      set(CMAKE_REQUIRED_FLAGS ${EXTRA_LINK_OPTIONS} "-Wl,--gc-sections")
++      set(CMAKE_REQUIRED_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} "-Wl,--gc-sections")
+       check_c_source_compiles("int main() {}" SUPPORTS_GC_SECTIONS)
+       if(SUPPORTS_GC_SECTIONS)
+         set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,--gc-sections)
+       else()
+-        set(CMAKE_REQUIRED_FLAGS ${EXTRA_LINK_OPTIONS} "-Wl,-dead_strip")
++        set(CMAKE_REQUIRED_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} "-Wl,-dead_strip")
+         check_c_source_compiles("int main() {}" SUPPORTS_DEAD_STRIP)
+         if(SUPPORTS_DEAD_STRIP)
+           set(EXTRA_LINK_OPTIONS ${EXTRA_LINK_OPTIONS} -Wl,-dead_strip)
+-- 
+2.49.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "mujoco" %}
 {% set namecxx = "libmujoco" %}
 {% set namepython = "mujoco-python" %}
-{% set version = "3.2.7" %}
+{% set version = "3.3.1" %}
 
 package:
   name: {{ name }}
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/deepmind/mujoco/archive/refs/tags/{{ version }}.tar.gz
-  sha256: c93d92aac96abb3a66ff28d89619e3bf3906c66f8636bd4803fda41198b19c74
+  sha256: 199457f83e15ddd14bf45e6cb089dc20f56c78a3975a84c424f4a67d59f1be66
   patches:
     - python_remove_avx.patch
     - cxx_devendor.patch
@@ -31,7 +31,7 @@ source:
 build:
   # See https://github.com/conda-forge/mujoco-feedstock/issues/22
   skip: true  # [(aarch64 or ppc64le or osx) and python_impl == 'pypy']
-  number: 2
+  number: 0
 
 outputs:
   - name: {{ namecxx }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ source:
     - add_samples_prefix.patch
     - add_simulate_prefix.patch
     - 1477.patch
+    - cmake-required-link-options.patch
 
 build:
   # See https://github.com/conda-forge/mujoco-feedstock/issues/22

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ source:
     - add_simulate_prefix.patch
     - 1477.patch
     - cmake-required-link-options.patch
+    - add-msys-windows-platform.patch
 
 build:
   # See https://github.com/conda-forge/mujoco-feedstock/issues/22


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

* Updates to MuJoCo 3.3.1.
* Adds `MSYS` as a Windows platform in MuJoCo's `make_sdist.sh`
* Runs `make_sdist.sh` with `bash -xe` for debugging, and matches MuJoCo's CI invocation
* Replaces `CMAKE_REQUIRED_FLAGS` with `CMAKE_REQUIRED_LINK_OPTIONS` to address linker error when running `build-locally.py` on macOS

<!--
Please add any other relevant info below:
-->
