### PR TITLE
Add mjx-* entry_ponts and mujoco-mjx-warp package

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -28,7 +28,7 @@ source:
       - patches/0016-Add-MSYS-as-a-Windows-platform.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:
@@ -288,9 +288,11 @@ outputs:
         # We only build for python_min otherwise the test will fail
         - if: py < python_min
           then: true
-      # jax upstream does not support anymore Python 3.9
-      # See https://github.com/conda-forge/jax-feedstock/pull/156
       script: python -m pip install ./mjx/ --no-deps -vv
+      python:
+        entry_points:
+          - mjx-testspeed = mujoco.mjx.testspeed:main
+          - mjx-viewer = mujoco.mjx.viewer:main
     requirements:
       host:
         - pip
@@ -324,6 +326,32 @@ outputs:
             - pytest
             - python ${{ python_min }}.*
 
+
+  - package:
+      name: mujoco-mjx-warp
+    build:
+      noarch: python
+      skip:
+        # This is a noarch: python package, so we only build it on linux64
+        - if: not linux64
+          then: true
+        # We only build for python_min otherwise the test will fail
+        - if: py < python_min
+          then: true
+    requirements:
+      host:
+        - python ${{ python_min }}.*
+      run:
+        - python >=${{ python_min }}
+        - ${{ pin_subpackage("mujoco-mjx", exact=True) }}
+        - warp-lang 1.8.1.*
+    tests:
+      - python:
+          imports:
+            - mujoco.mjx
+      - script:
+          - echo "Meta package to document the mujoco-mjx[warp] optional dependency on warp"
+
   - package:
       name: mujoco
     requirements:
@@ -331,7 +359,6 @@ outputs:
         - ${{ pin_subpackage("libmujoco", exact=True) }}
         - ${{ pin_subpackage("mujoco-samples", exact=True) }}
         - ${{ pin_subpackage("mujoco-simulate", exact=True) }}
-        - ${{ pin_subpackage("mujoco-python", upper_bound="x.x.x") }}
     tests:
       - python:
           imports:


### PR DESCRIPTION
See https://github.com/google-deepmind/mujoco/blob/3.3.5/mjx/pyproject.toml#L42-L44 and https://github.com/google-deepmind/mujoco/blob/3.3.5/mjx/pyproject.toml#L37-L40 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
