### PR TITLE
Add mujoco-sysid output for mujoco[sysid] extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-mujoco--python-green.svg)](https://anaconda.org/conda-forge/mujoco-python) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mujoco-python.svg)](https://anaconda.org/conda-forge/mujoco-python) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mujoco-python.svg)](https://anaconda.org/conda-forge/mujoco-python) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mujoco-python.svg)](https://anaconda.org/conda-forge/mujoco-python) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-mujoco--samples-green.svg)](https://anaconda.org/conda-forge/mujoco-samples) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mujoco-samples.svg)](https://anaconda.org/conda-forge/mujoco-samples) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mujoco-samples.svg)](https://anaconda.org/conda-forge/mujoco-samples) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mujoco-samples.svg)](https://anaconda.org/conda-forge/mujoco-samples) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-mujoco--simulate-green.svg)](https://anaconda.org/conda-forge/mujoco-simulate) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mujoco-simulate.svg)](https://anaconda.org/conda-forge/mujoco-simulate) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mujoco-simulate.svg)](https://anaconda.org/conda-forge/mujoco-simulate) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mujoco-simulate.svg)](https://anaconda.org/conda-forge/mujoco-simulate) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-mujoco--sysid-green.svg)](https://anaconda.org/conda-forge/mujoco-sysid) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mujoco-sysid.svg)](https://anaconda.org/conda-forge/mujoco-sysid) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mujoco-sysid.svg)](https://anaconda.org/conda-forge/mujoco-sysid) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mujoco-sysid.svg)](https://anaconda.org/conda-forge/mujoco-sysid) |
 
 Installing libmujoco
 ====================
@@ -98,16 +99,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `libmujoco, mujoco, mujoco-mjx, mujoco-python, mujoco-samples, mujoco-simulate` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `libmujoco, mujoco, mujoco-mjx, mujoco-python, mujoco-samples, mujoco-simulate, mujoco-sysid` can be installed with `conda`:
 
 ```
-conda install libmujoco mujoco mujoco-mjx mujoco-python mujoco-samples mujoco-simulate
+conda install libmujoco mujoco mujoco-mjx mujoco-python mujoco-samples mujoco-simulate mujoco-sysid
 ```
 
 or with `mamba`:
 
 ```
-mamba install libmujoco mujoco mujoco-mjx mujoco-python mujoco-samples mujoco-simulate
+mamba install libmujoco mujoco mujoco-mjx mujoco-python mujoco-samples mujoco-simulate mujoco-sysid
 ```
 
 It is possible to list all of the versions of `libmujoco` available on your platform with `conda`:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -13,8 +13,4 @@ github:
 provider:
   linux_aarch64: default
   linux_ppc64le: default
-remote_ci_setup:
-- conda-build>=24.1
-- conda-forge-ci-setup=4.*
-- rattler-build=0.43.*
 test: native_and_emulated

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -25,7 +25,7 @@ source:
       - patches/0016-Add-MSYS-as-a-Windows-platform.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:
@@ -335,6 +335,37 @@ outputs:
             # mujoco-mjx-warp to avoid confusion with https://github.com/google-deepmind/mujoco_warp
             # This pin is taken from https://github.com/google-deepmind/mujoco/blob/3.3.7/mjx/pyproject.toml#L37-L40
             - warp-lang 1.11.0.*
+  - package:
+      name: mujoco-sysid
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python ${{ python_min }}.*
+      run:
+        - python >=${{ python_min }}
+        - ${{ pin_subpackage("mujoco-python", upper_bound="x.x.x") }}
+        - absl-py
+        - colorama
+        - imageio
+        - imageio-ffmpeg
+        - jinja2
+        - matplotlib-base
+        - plotly
+        - pyyaml
+        - scipy
+        - tabulate
+        - typing_extensions
+    tests:
+      - python:
+          python_version: ${{ python_min }}.*
+          imports:
+            - mujoco.sysid
+      - script: pip check
+        requirements:
+          run:
+            - pip
+            - python
 
 
   - package:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -361,8 +361,7 @@ outputs:
           python_version: ${{ python_min }}.*
           imports:
             - mujoco.sysid
-      - pip_check: true
-
+          pip_check: true
 
   - package:
       name: mujoco

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -361,11 +361,7 @@ outputs:
           python_version: ${{ python_min }}.*
           imports:
             - mujoco.sysid
-      - script: pip check
-        requirements:
-          run:
-            - pip
-            - python
+      - pip_check: true
 
 
   - package:


### PR DESCRIPTION
Fixes #114

This PR adds a dedicated `mujoco-sysid` output to map the upstream `mujoco[sysid]` extra into conda-forge package outputs.
