### PR TITLE
Bump mujoco version to 3.8.0

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
 context:
-  version: "3.7.0"
+  version: "3.8.0"
 
 recipe:
   name: mujoco-split
@@ -8,7 +8,7 @@ recipe:
 
 source:
   - url: https://github.com/deepmind/mujoco/archive/refs/tags/${{ version }}.tar.gz
-    sha256: 16d6fce6858c02ebeb1d876a89ca288cb03321639a0ecccb19634a52f35a131f
+    sha256: 7c157cfd1cfccb806fba5649880af1a715d74e281c0894ee0d99a44c68af74c0
     patches:
       - patches/0001-python_remove_avx.patch
       - patches/0002-cxx_devendor.patch


### PR DESCRIPTION
fyi @oursland I prefer to release both 3.8.0 and 3.8.1 so the version if available if downstream projects as strict mujoco pinnings (it sometimes happen in my org).


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
